### PR TITLE
Feature ETP-2980: Fix entitiy model projected

### DIFF
--- a/libs/com.etendorx.generate_entities/src/main/java/com/etendorx/gen/generation/ProjectionsConverter.java
+++ b/libs/com.etendorx.generate_entities/src/main/java/com/etendorx/gen/generation/ProjectionsConverter.java
@@ -8,6 +8,8 @@ import com.etendorx.gen.beans.ProjectionEntityField;
 import org.apache.commons.lang3.StringUtils;
 import org.openbravo.base.model.Entity;
 import org.openbravo.base.model.ModelProvider;
+import org.openbravo.base.model.Property;
+import org.openbravo.base.model.Table;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -88,16 +90,61 @@ public class ProjectionsConverter {
   private ProjectionEntity convertEntity(ETRXProjectionEntity entity) {
     var projection = new ProjectionEntity(entity.getTable().getName(), entity.getExternalName(), entity.getIdentity());
     entity.getFields().forEach(f -> {
-      var type =
-          ModelProvider.getInstance().getColumnTypeName(entity.getTable(),
-              entity.getTable().getName() + "." + f.getProperty());
-      if(type == null) {
-        type = "Object";
-      }
+      var type = resolvePropertyType(entity.getTable(), f.getProperty());
       var field = new ProjectionEntityField(f.getName(), f.getProperty(), type);
+
+      // Set projectedEntity and projectedField for navigated properties
+      if (f.getProperty() != null && f.getProperty().contains(".")) {
+        String[] parts = f.getProperty().split("\\.", 2);
+        field.setProjectedEntity(parts[0]);
+        field.setProjectedField(parts[1]);
+      }
+
       projection.getFields().put(field.getName(), field);
     });
     return projection;
+  }
+
+  /**
+   * Resolves the type of a property, supporting navigated properties (e.g., businessPartner.name)
+   *
+   * @param table    The starting table
+   * @param property The property path (may contain dots for navigation)
+   * @return The resolved type name, or "Object" if not found
+   */
+  private String resolvePropertyType(Table table, String property) {
+    if (property == null || property.isEmpty()) {
+      return "Object";
+    }
+
+    // Check if it's a navigated property (contains a dot)
+    if (property.contains(".")) {
+      String[] parts = property.split("\\.", 2);
+      String navigationProperty = parts[0];
+      String remainingPath = parts[1];
+
+      // Find the navigation property in the current entity
+      Entity currentEntity = ModelProvider.getInstance().getEntityByTableName(table.getTableName());
+      if (currentEntity != null) {
+        Property navProp = currentEntity.getProperty(navigationProperty, false);
+        if (navProp != null && navProp.getTargetEntity() != null) {
+          // Recursively resolve the remaining path in the target entity's table
+          String targetTableName = navProp.getTargetEntity().getTableName();
+          if (targetTableName != null) {
+            Table targetTable = ModelProvider.getInstance().getTable(targetTableName);
+            if (targetTable != null) {
+              return resolvePropertyType(targetTable, remainingPath);
+            }
+          }
+        }
+      }
+      return "Object";
+    }
+
+    // Simple property - resolve directly
+    String type = ModelProvider.getInstance().getColumnTypeName(table,
+        table.getName() + "." + property);
+    return type != null ? type : "Object";
   }
 
   /**

--- a/libs/com.etendorx.generate_entities/src/main/resources/org/openbravo/base/gen/entityModelProjected.ftl
+++ b/libs/com.etendorx.generate_entities/src/main/resources/org/openbravo/base/gen/entityModelProjected.ftl
@@ -87,8 +87,15 @@ public class ${newClassName}${projectionName?cap_first}Model extends Representat
     ${field.type} ${field.name};
 
     <#elseif field.value??>
+    <#-- Only add if the field does not exist in entity.properties to avoid duplicates -->
+    <#assign fieldExistsInEntity = false>
+    <#list entity.properties as p>
+        <#if p.javaName == field.name><#assign fieldExistsInEntity = true></#if>
+    </#list>
+    <#if !fieldExistsInEntity>
     ${field.type} ${field.name};
 
+    </#if>
     </#if>
 </#list>
 


### PR DESCRIPTION
This pull request enhances the handling of property types and field generation for projected entities, especially for navigated properties (e.g., `businessPartner.name`). The main improvements are the introduction of recursive property type resolution and prevention of duplicate field declarations in generated model classes.

**Projection property type resolution:**

* Added the `resolvePropertyType` method in `ProjectionsConverter.java` to recursively resolve the type of navigated properties, ensuring correct type assignment even for deep property paths.
* Updated the field creation logic in `convertEntity` to use the new `resolvePropertyType` method, and set `projectedEntity` and `projectedField` for navigated properties.
* Imported `Property` and `Table` to support the new type resolution logic.

**Template field generation:**

* Modified the entity model projection template (`entityModelProjected.ftl`) to check for existing properties before declaring a field, preventing duplicate field declarations in the generated class.