### PR TITLE
Issue #229: Remove non-existent C_ExtBP_Config entries from urlData.csv

### DIFF
--- a/modules_core/com.etendorx.das/src/test/resources/urlData.csv
+++ b/modules_core/com.etendorx.das/src/test/resources/urlData.csv
@@ -178,7 +178,6 @@ http://localhost:8092/JOBS_Job
 http://localhost:8092/InvoiceTaxCashVAT
 http://localhost:8092/InvoiceDiscount
 http://localhost:8092/SalaryCategory
-http://localhost:8092/C_ExtBP_Config
 http://localhost:8092/SOLReservedStock
 http://localhost:8092/ADTab
 http://localhost:8092/ADProcessAccess
@@ -267,7 +266,6 @@ http://localhost:8092/ADMonthTrl
 http://localhost:8092/UOMConversion
 http://localhost:8092/ServicePriceRuleRange
 http://localhost:8092/ManufacturingOperationIndirectCost
-http://localhost:8092/C_ExtBP_Config_Filter_Opt
 http://localhost:8092/PricingAdjustmentTrl
 http://localhost:8092/ProductAccounts
 http://localhost:8092/OBULOG_Config
@@ -297,7 +295,6 @@ http://localhost:8092/OBWCL_StockByWarehouseView
 http://localhost:8092/OrganizationWarehouse
 http://localhost:8092/ADModuleMerge
 http://localhost:8092/MaterialMgmtABCActivity
-http://localhost:8092/C_ExtBP_Config_Property
 http://localhost:8092/FinancialMgmtAccountingFact
 http://localhost:8092/ManufacturingMeasureGroup
 http://localhost:8092/FinancialMgmtAcctRptGroup
@@ -361,7 +358,6 @@ http://localhost:8092/FinancialMgmtTaxRegisterTypeLines
 http://localhost:8092/OBUIAPP_Note
 http://localhost:8092/FIN_Payment_Sched_Inv_V
 http://localhost:8092/ADRoleOrganization
-http://localhost:8092/C_ExtBP_Config_Prop_Opt
 http://localhost:8092/LandedCostType
 http://localhost:8092/ServiceProductCategory
 http://localhost:8092/ColorPalette
@@ -383,7 +379,6 @@ http://localhost:8092/ProductOrg
 http://localhost:8092/ADDimensionMapping
 http://localhost:8092/ADClusterServiceSettings
 http://localhost:8092/CharacteristicSubset
-http://localhost:8092/C_ExtBP_Config_Filter
 http://localhost:8092/FinancialMgmtPaymentExecutionHistoryV
 http://localhost:8092/APRM_FinAcc_Transaction_acct_v
 http://localhost:8092/AD_CreateFact_template

--- a/modules_core/com.etendorx.das/src/test/resources/urlData.csv
+++ b/modules_core/com.etendorx.das/src/test/resources/urlData.csv
@@ -197,8 +197,6 @@ http://localhost:8092/BusinessPartnerCategory
 http://localhost:8092/CostAdjustmentLine
 http://localhost:8092/ProjectType
 http://localhost:8092/FinancialMgmtAcctRptNode
-http://localhost:8092/OBSOID_User_Identifier
-http://localhost:8092/OBSEIG_Defaults
 http://localhost:8092/MaterialMgmtInternalConsumptionLine
 http://localhost:8092/OrganizationInformation
 http://localhost:8092/ADProcessParameter


### PR DESCRIPTION
## Summary

- Removes 5 stale URL entries from `urlData.csv` in `com.etendorx.das` test resources that referenced `C_ExtBP_Config` entities no longer present in the system.
- Affected entries: `/C_ExtBP_Config`, `/C_ExtBP_Config_Filter_Opt`, `/C_ExtBP_Config_Property`, `/C_ExtBP_Config_Prop_Opt`, `/C_ExtBP_Config_Filter`.

Closes #229
ETP-3670